### PR TITLE
Fix ALB module flags #32 / HTTP for test purposes

### DIFF
--- a/terraform/modules/loadbalancer/main.tf
+++ b/terraform/modules/loadbalancer/main.tf
@@ -1,6 +1,10 @@
 locals {
-  targetPort     = 443
-  targetProtocol = "HTTPS"
+  #  Waiting for a valid acm certificate
+  #  targetPort     = 443
+  #  targetProtocol = "HTTPS"
+  #  Let's test with http only
+  targetPort     = 80
+  targetProtocol = "HTTP"
 }
 
 resource "aws_lb" "this" {
@@ -8,7 +12,7 @@ resource "aws_lb" "this" {
   internal                   = false
   load_balancer_type         = "application"
   subnets                    = var.subnets
-  enable_deletion_protection = true
+  enable_deletion_protection = false
 
   tags = {
     Name = "wordpress-lb"


### PR DESCRIPTION
1 - delete protection should be disabled

2- 443 port listener should be commented out for now at least  or we need to find out how to integrate with ASM. I'd say let's go with port 80 for now

3- Enable HTTP /80 for testing purposes